### PR TITLE
Возможность использовать vrunner, установленный глобально. Опциональный шаг установки локальных зависимостей

### DIFF
--- a/src/ru/pulsar/jenkins/library/IStepExecutor.groovy
+++ b/src/ru/pulsar/jenkins/library/IStepExecutor.groovy
@@ -19,6 +19,8 @@ interface IStepExecutor {
 
     String readFile(String file, String encoding)
 
+    boolean fileExists(String file)
+
     void echo(message)
 
     int cmd(String script, boolean returnStatus)

--- a/src/ru/pulsar/jenkins/library/StepExecutor.groovy
+++ b/src/ru/pulsar/jenkins/library/StepExecutor.groovy
@@ -38,6 +38,11 @@ class StepExecutor implements IStepExecutor {
     }
 
     @Override
+    boolean fileExists(String file) {
+        steps.fileExists file
+    }
+
+    @Override
     FileWrapper[] findFiles(String glob, String excludes = '') {
         steps.findFiles glob: glob, excludes: excludes
     }

--- a/src/ru/pulsar/jenkins/library/steps/Bdd.groovy
+++ b/src/ru/pulsar/jenkins/library/steps/Bdd.groovy
@@ -4,6 +4,7 @@ import ru.pulsar.jenkins.library.IStepExecutor
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
 import ru.pulsar.jenkins.library.ioc.ContextRegistry
 import ru.pulsar.jenkins.library.utils.Logger
+import ru.pulsar.jenkins.library.utils.VRunner
 
 class Bdd implements Serializable {
 
@@ -32,7 +33,8 @@ class Bdd implements Serializable {
             steps.catchError {
                 config.bddOptions.vrunnerSteps.each {
                     Logger.println("Шаг запуска сценариев командой ${it}")
-                    steps.cmd("oscript_modules/bin/vrunner ${it} --ibconnection \"/F./build/ib\"")
+                    String vrunnerPath = VRunner.getVRunnerPath();
+                    steps.cmd("$vrunnerPath ${it} --ibconnection \"/F./build/ib\"")
                 }
             }
         }

--- a/src/ru/pulsar/jenkins/library/steps/InitInfobase.groovy
+++ b/src/ru/pulsar/jenkins/library/steps/InitInfobase.groovy
@@ -5,6 +5,7 @@ import ru.pulsar.jenkins.library.IStepExecutor
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
 import ru.pulsar.jenkins.library.ioc.ContextRegistry
 import ru.pulsar.jenkins.library.utils.Logger
+import ru.pulsar.jenkins.library.utils.VRunner
 
 class InitInfobase implements Serializable {
 
@@ -29,12 +30,14 @@ class InitInfobase implements Serializable {
         List<String> logosConfig = ["LOGOS_CONFIG=$config.logosConfig"]
         steps.withEnv(logosConfig) {
 
+            String vrunnerPath = VRunner.getVRunnerPath();
+
             if (config.initInfobaseOptions.runMigration) {
                 Logger.println("Запуск миграции ИБ")
 
                 // Запуск миграции
                 steps.catchError {
-                    steps.cmd('oscript_modules/bin/vrunner run --command "ЗапуститьОбновлениеИнформационнойБазы;ЗавершитьРаботуСистемы;" --execute \\$runnerRoot/epf/ЗакрытьПредприятие.epf --ibconnection "/F./build/ib"')
+                    steps.cmd(vrunnerPath + ' run --command "ЗапуститьОбновлениеИнформационнойБазы;ЗавершитьРаботуСистемы;" --execute \\$runnerRoot/epf/ЗакрытьПредприятие.epf --ibconnection "/F./build/ib"')
                 }
             } else {
                 Logger.println("Шаг миграции ИБ выключен")
@@ -46,12 +49,12 @@ class InitInfobase implements Serializable {
                     files = files.sort new OrderBy( { it.name })
                     files.each {
                         Logger.println("Первичная инициализация файлом ${it.path}")
-                        steps.cmd("oscript_modules/bin/vrunner vanessa --settings ${it.path} --ibconnection \"/F./build/ib\"")
+                        steps.cmd("$vrunnerPath vanessa --settings ${it.path} --ibconnection \"/F./build/ib\"")
                     }
                 } else {
                     config.initInfobaseOptions.additionalInitializationSteps.each {
                         Logger.println("Первичная инициализация командой ${it}")
-                        steps.cmd("oscript_modules/bin/vrunner ${it} --ibconnection \"/F./build/ib\"")
+                        steps.cmd("$vrunnerPath ${it} --ibconnection \"/F./build/ib\"")
                     }
                 }
             }

--- a/src/ru/pulsar/jenkins/library/utils/VRunner.groovy
+++ b/src/ru/pulsar/jenkins/library/utils/VRunner.groovy
@@ -1,0 +1,20 @@
+package ru.pulsar.jenkins.library.utils
+
+import ru.pulsar.jenkins.library.IStepExecutor
+import ru.pulsar.jenkins.library.ioc.ContextRegistry
+
+class VRunner {
+
+    static String getVRunnerPath() {
+
+        IStepExecutor steps = ContextRegistry.getContext().getStepExecutor()
+
+        String vrunnerBinary = steps.isUnix() ? "vrunner" : "vrunner.bat";
+        String vrunnerPath = "oscript_modules/bin/$vrunnerBinary";
+        if (!steps.fileExists(vrunnerPath)) {
+            vrunnerPath = vrunnerBinary;
+        }
+
+        return vrunnerPath;
+    }
+}

--- a/test/unit/groovy/ru/pulsar/jenkins/library/utils/TestUtils.java
+++ b/test/unit/groovy/ru/pulsar/jenkins/library/utils/TestUtils.java
@@ -34,6 +34,11 @@ public class TestUtils {
       return FileUtils.readFileToString(new File(file), encoding);
     });
 
+    when(steps.fileExists(anyString())).thenAnswer(invocation -> {
+      String file = invocation.getArgument(0);
+      return new File(file).exists();
+    });
+
     return steps;
   }
 

--- a/vars/initFromStorage.groovy
+++ b/vars/initFromStorage.groovy
@@ -1,4 +1,5 @@
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
+import ru.pulsar.jenkins.library.utils.VRunner
 import ru.pulsar.jenkins.library.utils.VersionParser
 
 def call(JobConfiguration jobConfiguration) {
@@ -17,6 +18,7 @@ def call(JobConfiguration jobConfiguration) {
             variable: 'STORAGE_PATH'
         )
     ]) {
-        cmd "oscript_modules/bin/vrunner init-dev --storage --storage-name $STORAGE_PATH --storage-user $STORAGE_USR --storage-pwd $STORAGE_PSW $storageVersionParameter --ibconnection \"/F./build/ib\""
+        String vrunnerPath = VRunner.getVRunnerPath();
+        cmd "$vrunnerPath init-dev --storage --storage-name $STORAGE_PATH --storage-user $STORAGE_USR --storage-pwd $STORAGE_PSW $storageVersionParameter --ibconnection \"/F./build/ib\""
     }
 }

--- a/vars/installLocalDependencies.groovy
+++ b/vars/installLocalDependencies.groovy
@@ -1,3 +1,10 @@
+import ru.pulsar.jenkins.library.utils.Logger
+
 def call() {
+    if (!fileExists("packagedef")) {
+        return
+    }
+
+    Logger.println("Установка локальных зависимостей OneScript")
     cmd("opm install -l")
 }

--- a/vars/syntaxCheck.groovy
+++ b/vars/syntaxCheck.groovy
@@ -2,6 +2,7 @@ import hudson.FilePath
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
 import ru.pulsar.jenkins.library.ioc.ContextRegistry
 import ru.pulsar.jenkins.library.utils.FileUtils
+import ru.pulsar.jenkins.library.utils.VRunner
 
 def call(JobConfiguration config) {
 
@@ -27,7 +28,8 @@ def call(JobConfiguration config) {
     String outPath = pathToJUnitReport.getParent()
     createDir(outPath)
 
-    String command = 'oscript_modules/bin/vrunner syntax-check --ibconnection "/F./build/ib"'
+    String vrunnerPath = VRunner.getVRunnerPath();
+    String command = "$vrunnerPath syntax-check --ibconnection \"/F./build/ib\""
 
     // Временно убрал передачу параметра.
     // См. https://github.com/vanessa-opensource/vanessa-runner/issues/361


### PR DESCRIPTION
Перед вызовом `opm install -l` добавлена проверка на наличие packagedef в корне.
Перед запуском vrunner осуществляется попытка найти его в oscript_modules, иначе используется vrunner из глобальной области видимости.

Closes #1 